### PR TITLE
Fix warnings about missing dyn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "protobuf-build"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio-compiler 0.5.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protobuf-build"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Nick Cameron <nrc@ncameron.org>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -199,7 +199,7 @@ where
     )?;
     writeln!(
         buf,
-        "fn as_any(&self) -> &::std::any::Any {{ self as &::std::any::Any }}",
+        "fn as_any(&self) -> &dyn ::std::any::Any {{ self as &dyn ::std::any::Any }}",
     )?;
     writeln!(
         buf,


### PR DESCRIPTION
A new warning from the compiler, I think.

PTAL @ice1000 