### PR TITLE
Fix name of Message trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protobuf-build"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["Nick Cameron <nrc@ncameron.org>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
Closes #17

Also simplifies the logic to always use `default` rather than `new_`.

PTAL @ice1000 