### PR TITLE
Implement a builder API and some general refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,6 @@ matrix:
 
 script:
   - cargo test --all -- --nocapture
+  - cargo test --no-default-features --features prost-codec --all -- --nocapture
+  - cargo test --no-default-features --features grpcio-protobuf-codec --all -- --nocapture
+  - cargo test --no-default-features --features grpcio-prost-codec --all -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,6 @@ version = "0.9.0"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio-compiler 0.5.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,10 +242,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "protobuf-build"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio-compiler 0.5.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "Utility functions for generating Rust code from protobufs (using 
 default = ["protobuf-codec"]
 protobuf-codec = ["protobuf-codegen", "protobuf"]
 grpcio-protobuf-codec = ["grpcio-compiler/protobuf-codec", "protobuf-codec"]
-prost-codec = ["grpcio-compiler/prost-codec", "syn", "quote", "bitflags", "prost-build"]
+prost-codec = ["syn", "quote", "bitflags", "prost-build"]
 grpcio-prost-codec = ["grpcio-compiler/prost-codec", "prost-codec"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "Utility functions for generating Rust code from protobufs (using 
 default = ["protobuf-codec"]
 protobuf-codec = ["protobuf-codegen", "protobuf"]
 grpcio-protobuf-codec = ["grpcio-compiler/protobuf-codec", "protobuf-codec"]
-prost-codec = ["syn", "quote", "bitflags", "prost-build"]
+prost-codec = ["syn", "quote", "prost-build"]
 grpcio-prost-codec = ["grpcio-compiler/prost-codec", "prost-codec"]
 
 [dependencies]
@@ -22,4 +22,4 @@ prost-build = { version = "0.5", optional = true }
 regex = { version = "1.1" }
 syn = { version = "0.15", features = ["full"], optional = true }
 quote = { version = "0.6", optional = true }
-bitflags = { version = "1.0.4", optional = true }
+bitflags = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protobuf-build"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Nick Cameron <nrc@ncameron.org>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,6 +14,7 @@ prost-codec = ["syn", "quote", "bitflags", "prost-build"]
 grpcio-prost-codec = ["grpcio-compiler/prost-codec", "prost-codec"]
 
 [dependencies]
+lazy_static = "1.3"
 protobuf = { version = "2", optional = true }
 protobuf-codegen = { version = "2", optional = true }
 grpcio-compiler = { version = "0.5.0-alpha", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ prost-codec = ["syn", "quote", "prost-build"]
 grpcio-prost-codec = ["grpcio-compiler/prost-codec", "prost-codec"]
 
 [dependencies]
-lazy_static = "1.3"
 protobuf = { version = "2", optional = true }
 protobuf-codegen = { version = "2", optional = true }
 grpcio-compiler = { version = "0.5.0-alpha", default-features = false, optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,4 @@
 // Copyright 2019 PingCAP, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 //! Utility functions for generating Rust code from protobuf specifications.
 //!
@@ -17,14 +6,25 @@
 //! scripts, not in production.
 
 #[cfg(feature = "prost-codec")]
+mod wrapper;
+
+#[cfg(feature = "prost-codec")]
 pub use crate::wrapper::GenOpt;
+
+#[cfg(feature = "protobuf-codec")]
+mod protobuf_impl;
+#[cfg(feature = "protobuf-codec")]
+pub use protobuf_impl::*;
+
+#[cfg(feature = "prost-codec")]
+mod prost_impl;
+#[cfg(feature = "prost-codec")]
+pub use prost_impl::*;
+
 use std::fmt::Debug;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::Path;
-
-#[cfg(feature = "prost-codec")]
-mod wrapper;
 
 /// Generate Rust files from proto files (`files`).
 pub fn generate_files<T: AsRef<Path> + Debug>(includes: &[T], files: &[T], out_dir: &str) {
@@ -88,159 +88,6 @@ pub fn generate_files<T: AsRef<Path> + Debug>(includes: &[T], files: &[T], out_d
     }
 }
 
-/// Use rust-protobuf to generate Rust files from proto files (`files`).
-#[cfg(feature = "protobuf-codec")]
-mod protobuf_imps {
-    use regex::Regex;
-    use std::env;
-    use std::fmt::Debug;
-    use std::fs::{self, File};
-    use std::io::{Read, Write};
-    use std::path::Path;
-    use std::process::Command;
-    use std::str::from_utf8;
-
-    pub fn get_protoc() -> String {
-        let protoc_bin_name = match (env::consts::OS, env::consts::ARCH) {
-            ("linux", "x86") => "protoc-linux-x86_32",
-            ("linux", "x86_64") => "protoc-linux-x86_64",
-            ("linux", "aarch64") => "protoc-linux-aarch_64",
-            ("linux", "ppcle64") => "protoc-linux-ppcle_64",
-            ("macos", "x86_64") => "protoc-osx-x86_64",
-            ("windows", _) => "protoc-win32.exe",
-            _ => return "protoc".to_owned(),
-        };
-        let bin_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("bin")
-            .join(protoc_bin_name);
-        format!("{}", bin_path.display())
-    }
-
-    /// Check that the user's installed version of the protobuf compiler is 3.1.x.
-    pub fn check_protoc_version(protoc: &str) {
-        let ver_re = Regex::new(r"([0-9]+)\.([0-9]+)\.[0-9]").unwrap();
-        let ver = Command::new(protoc)
-            .arg("--version")
-            .output()
-            .expect("Program `protoc` not installed (is it in PATH?).");
-        let caps = ver_re.captures(from_utf8(&ver.stdout).unwrap()).unwrap();
-        let major = caps.get(1).unwrap().as_str().parse::<i16>().unwrap();
-        let minor = caps.get(2).unwrap().as_str().parse::<i16>().unwrap();
-        if major == 3 && minor < 1 || major < 3 {
-            panic!(
-                "Invalid version of protoc (required at least 3.1.x, get {}.{}.x).",
-                major, minor,
-            );
-        }
-    }
-    pub fn generate<T: AsRef<Path> + Debug>(includes: &[T], files: &[T], out_dir: &str) {
-        check_protoc_version(&get_protoc());
-        let mut cmd = Command::new(get_protoc());
-        let desc_file = format!("{}/mod.desc", out_dir);
-        for i in includes {
-            cmd.arg(format!("-I{}", i.as_ref().display()));
-        }
-        cmd.arg("--include_imports")
-            .arg("--include_source_info")
-            .arg("-o")
-            .arg(&desc_file);
-        for f in files {
-            cmd.arg(&format!("{}", f.as_ref().display()));
-        }
-        println!("executing {:?}", cmd);
-        match cmd.status() {
-            Ok(e) if e.success() => {}
-            e => panic!("failed to generate descriptor set files: {:?}", e),
-        }
-
-        let desc_bytes = std::fs::read(&desc_file).unwrap();
-        let desc: protobuf::descriptor::FileDescriptorSet =
-            protobuf::parse_from_bytes(&desc_bytes).unwrap();
-        let mut files_to_generate = Vec::new();
-        'outer: for file in files {
-            for include in includes {
-                if let Ok(truncated) = file.as_ref().strip_prefix(include) {
-                    files_to_generate.push(format!("{}", truncated.display()));
-                    continue 'outer;
-                }
-            }
-
-            panic!("file {:?} is not found in includes {:?}", file, includes);
-        }
-
-        protobuf_codegen::gen_and_write(
-            desc.get_file(),
-            &files_to_generate,
-            &Path::new(out_dir),
-            &protobuf_codegen::Customize::default(),
-        )
-        .unwrap();
-        generate_grpcio(&desc.get_file(), &files_to_generate, out_dir);
-        replace_read_unknown_fields(out_dir);
-    }
-
-    #[cfg(feature = "grpcio-protobuf-codec")]
-    pub fn generate_grpcio(
-        desc: &[protobuf::descriptor::FileDescriptorProto],
-        files_to_generate: &[String],
-        out_dir: &str,
-    ) {
-        use std::io::Write;
-
-        let output_dir = std::path::Path::new(out_dir);
-        let results = grpcio_compiler::codegen::gen(desc, &files_to_generate);
-        for res in results {
-            let out_file = output_dir.join(&res.name);
-            let mut f = std::fs::File::create(&out_file).unwrap();
-            f.write_all(&res.content).unwrap();
-        }
-    }
-
-    #[cfg(all(feature = "protobuf-codec", not(feature = "grpcio-protobuf-codec")))]
-    pub fn generate_grpcio(_: &[protobuf::descriptor::FileDescriptorProto], _: &[String], _: &str) {
-    }
-
-    /// Convert protobuf files to use the old way of reading protobuf enums.
-    // FIXME: Remove this once stepancheg/rust-protobuf#233 is resolved.
-    pub fn replace_read_unknown_fields(out_dir: &str) {
-        let regex =
-            Regex::new(r"::protobuf::rt::read_proto3_enum_with_unknown_fields_into\(([^,]+), ([^,]+), &mut ([^,]+), [^\)]+\)\?").unwrap();
-        for f in fs::read_dir(out_dir).unwrap() {
-            let path = match f {
-                Ok(p) => p.path(),
-                Err(e) => panic!("failed to list {}: {:?}", out_dir, e),
-            };
-            if path.extension() != Some(std::ffi::OsStr::new("rs")) {
-                continue;
-            }
-
-            let mut text = String::new();
-            let mut f = File::open(&path).unwrap();
-            f.read_to_string(&mut text)
-                .expect("Couldn't read source file");
-
-            // FIXME Rustfmt bug in string literals
-            #[rustfmt::skip]
-            let text = {
-                regex.replace_all(
-                    &text,
-                    "if $1 == ::protobuf::wire_format::WireTypeVarint {\
-                        $3 = $2.read_enum()?;\
-                    } else {\
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));\
-                    }",
-                )
-            };
-            let mut out = File::create(&path).unwrap();
-            out.write_all(text.as_bytes())
-                .expect("Could not write source file");
-        }
-    }
-}
-
-#[cfg(feature = "protobuf-codec")]
-pub use protobuf_imps::*;
-
 /// Use prost to generate Rust files from proto files (`files`).
 #[cfg(feature = "prost-codec")]
 pub fn generate<T: AsRef<Path>>(includes: &[T], files: &[T], out_dir: &str) {
@@ -266,55 +113,3 @@ pub fn generate<T: AsRef<Path>>(includes: &[T], files: &[T], out_dir: &str) {
         GenOpt::all(),
     );
 }
-
-#[cfg(feature = "prost-codec")]
-mod prost_imps {
-    use super::wrapper::GenOpt;
-    use std::fs;
-    use std::path::Path;
-    use std::process::Command;
-
-    pub fn rustfmt(file_path: &Path) {
-        let output = Command::new("rustfmt")
-            .arg(file_path.to_str().unwrap())
-            .output();
-        if !output.map(|o| o.status.success()).unwrap_or(false) {
-            eprintln!("Rustfmt failed");
-        }
-    }
-
-    pub fn generate_wrappers<T: AsRef<str>>(file_names: &[T], out_dir: &str, gen_opt: GenOpt) {
-        for file in file_names {
-            let gen = super::wrapper::WrapperGen::new(file.as_ref(), gen_opt);
-            gen.write(out_dir);
-        }
-    }
-
-    /// Returns a list of module names corresponding to the Rust files in a directory.
-    ///
-    /// Note that this does not read the files so will miss inline modules, it only
-    /// looks at filenames,
-    pub fn module_names_for_dir(directory_name: &str) -> Vec<String> {
-        let mut mod_names: Vec<_> = fs::read_dir(directory_name)
-            .expect("Couldn't read directory")
-            .filter_map(|e| {
-                let file_name = e.expect("Couldn't list file").file_name();
-                let file_name = file_name.to_string_lossy();
-                if !file_name.ends_with(".rs") {
-                    return None;
-                }
-                file_name
-                    .split(".rs")
-                    .next()
-                    .filter(|n| !n.starts_with("wrapper_"))
-                    .map(ToOwned::to_owned)
-            })
-            .collect();
-
-        mod_names.sort();
-        mod_names
-    }
-}
-
-#[cfg(feature = "prost-codec")]
-pub use prost_imps::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,25 +21,35 @@ mod prost_impl;
 #[cfg(feature = "prost-codec")]
 pub use prost_impl::*;
 
+use lazy_static::lazy_static;
 use std::fmt::Debug;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::Path;
 
+lazy_static! {
+    static ref OUT_DIR: String = {
+        format!(
+            "{}/protos",
+            std::env::var("OUT_DIR").expect("No OUT_DIR defined")
+        )
+    };
+}
+
 /// Generate Rust files from proto files (`files`).
-pub fn generate_files<T: AsRef<Path> + Debug>(includes: &[T], files: &[T], out_dir: &str) {
-    if Path::new(&out_dir).exists() {
-        fs::remove_dir_all(&out_dir).unwrap();
+pub fn generate_files<T: AsRef<Path> + Debug>(includes: &[T], files: &[T]) {
+    if Path::new(&*OUT_DIR).exists() {
+        fs::remove_dir_all(&*OUT_DIR).unwrap();
     }
-    fs::create_dir_all(&out_dir).unwrap();
-    generate(includes, files, out_dir);
+    fs::create_dir_all(&*OUT_DIR).unwrap();
+    generate(includes, files);
     let mut generated = Vec::new();
-    let modules: Vec<_> = fs::read_dir(out_dir)
+    let modules: Vec<_> = fs::read_dir(&*OUT_DIR)
         .unwrap()
         .filter_map(|res| {
             let path = match res {
                 Ok(e) => e.path(),
-                Err(e) => panic!("failed to list {}: {:?}", out_dir, e),
+                Err(e) => panic!("failed to list {}: {:?}", *OUT_DIR, e),
             };
             if path.extension() == Some(std::ffi::OsStr::new("rs")) {
                 generated.push(format!("{}", path.display()));
@@ -50,7 +60,7 @@ pub fn generate_files<T: AsRef<Path> + Debug>(includes: &[T], files: &[T], out_d
             }
         })
         .collect();
-    let mut f = File::create(format!("{}/mod.rs", out_dir)).unwrap();
+    let mut f = File::create(format!("{}/mod.rs", *OUT_DIR)).unwrap();
     for (module, file_name) in &modules {
         if cfg!(feature = "protobuf-codec") {
             writeln!(f, "pub mod {};", module).unwrap();
@@ -72,7 +82,7 @@ pub fn generate_files<T: AsRef<Path> + Debug>(includes: &[T], files: &[T], out_d
             level = level
         )
         .unwrap();
-        if Path::new(&format!("{}/wrapper_{}.rs", out_dir, file_name)).exists() {
+        if Path::new(&format!("{}/wrapper_{}.rs", *OUT_DIR, file_name)).exists() {
             writeln!(
                 f,
                 "{:level$}include!(\"wrapper_{}.rs\");",
@@ -86,30 +96,4 @@ pub fn generate_files<T: AsRef<Path> + Debug>(includes: &[T], files: &[T], out_d
             writeln!(f, "{:1$}}}", "", l).unwrap();
         }
     }
-}
-
-/// Use prost to generate Rust files from proto files (`files`).
-#[cfg(feature = "prost-codec")]
-pub fn generate<T: AsRef<Path>>(includes: &[T], files: &[T], out_dir: &str) {
-    #[cfg(feature = "grpcio-prost-codec")]
-    {
-        grpcio_compiler::prost_codegen::compile_protos(files, includes, out_dir).unwrap();
-    }
-    #[cfg(not(feature = "grpcio-prost-codec"))]
-    {
-        prost_build::Config::new()
-            .out_dir(out_dir)
-            .compile_protos(files, includes)
-            .unwrap();
-    }
-
-    let mod_names = module_names_for_dir(out_dir);
-    generate_wrappers(
-        &mod_names
-            .iter()
-            .map(|m| format!("{}/{}.rs", out_dir, m))
-            .collect::<Vec<_>>(),
-        out_dir,
-        GenOpt::all(),
-    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ impl Builder {
         assert!(!self.files.is_empty(), "No files specified for generation");
         prep_out_dir();
         self.generate_files();
-        self.generate_mod_files();
+        self.generate_mod_file();
     }
 
     pub fn wrapper_options(&mut self, wrapper_opts: GenOpt) -> &mut Self {
@@ -106,12 +106,13 @@ impl Builder {
         self
     }
 
-    fn generate_mod_files(&self) {
+    fn generate_mod_file(&self) {
         let mut f = File::create(format!("{}/mod.rs", *OUT_DIR)).unwrap();
 
         let modules = list_rs_files().filter_map(|path| {
             let name = path.file_stem().unwrap().to_str().unwrap();
             if name.starts_with("wrapper_")
+                || name == "mod"
                 || self.include_black_list.iter().any(|i| name.contains(i))
             {
                 return None;
@@ -136,6 +137,12 @@ impl Builder {
             }
             writeln!(f, "{}", "}\n".repeat(level)).unwrap();
         }
+    }
+}
+
+impl Default for Builder {
+    fn default() -> Builder {
+        Builder::new()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,25 +7,24 @@
 
 #[cfg(feature = "prost-codec")]
 mod wrapper;
-
 #[cfg(feature = "prost-codec")]
 pub use crate::wrapper::GenOpt;
 
 #[cfg(feature = "protobuf-codec")]
 mod protobuf_impl;
 #[cfg(feature = "protobuf-codec")]
-pub use protobuf_impl::*;
+use protobuf_impl::generate;
 
 #[cfg(feature = "prost-codec")]
 mod prost_impl;
 #[cfg(feature = "prost-codec")]
-pub use prost_impl::*;
+use prost_impl::generate;
 
 use lazy_static::lazy_static;
 use std::fmt::Debug;
 use std::fs::{self, File};
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 lazy_static! {
     static ref OUT_DIR: String = {
@@ -38,62 +37,58 @@ lazy_static! {
 
 /// Generate Rust files from proto files (`files`).
 pub fn generate_files<T: AsRef<Path> + Debug>(includes: &[T], files: &[T]) {
+    prep_out_dir();
+    generate(includes, files);
+    generate_mod_files();
+}
+
+fn prep_out_dir() {
     if Path::new(&*OUT_DIR).exists() {
         fs::remove_dir_all(&*OUT_DIR).unwrap();
     }
     fs::create_dir_all(&*OUT_DIR).unwrap();
-    generate(includes, files);
-    let mut generated = Vec::new();
-    let modules: Vec<_> = fs::read_dir(&*OUT_DIR)
-        .unwrap()
-        .filter_map(|res| {
-            let path = match res {
-                Ok(e) => e.path(),
-                Err(e) => panic!("failed to list {}: {:?}", *OUT_DIR, e),
-            };
-            if path.extension() == Some(std::ffi::OsStr::new("rs")) {
-                generated.push(format!("{}", path.display()));
-                let name = path.file_stem().unwrap().to_str().unwrap();
-                Some((name.replace('-', "_"), name.to_owned()))
-            } else {
-                None
-            }
-        })
-        .collect();
+}
+
+fn generate_mod_files() {
     let mut f = File::create(format!("{}/mod.rs", *OUT_DIR)).unwrap();
-    for (module, file_name) in &modules {
+
+    let modules = list_rs_files().filter_map(|path| {
+        let name = path.file_stem().unwrap().to_str().unwrap();
+        if name.starts_with("wrapper_") {
+            return None;
+        }
+        Some((name.replace('-', "_"), name.to_owned()))
+    });
+
+    for (module, file_name) in modules {
         if cfg!(feature = "protobuf-codec") {
             writeln!(f, "pub mod {};", module).unwrap();
             continue;
         }
-        if module.starts_with("wrapper_") {
-            continue;
-        }
+
         let mut level = 0;
         for part in module.split('.') {
-            writeln!(f, "{:level$}pub mod {} {{", "", part, level = level).unwrap();
+            writeln!(f, "pub mod {} {{", part).unwrap();
             level += 1;
         }
-        writeln!(
-            f,
-            "{:level$}include!(\"{}.rs\");",
-            "",
-            file_name,
-            level = level
-        )
-        .unwrap();
+        writeln!(f, "include!(\"{}.rs\");", file_name,).unwrap();
         if Path::new(&format!("{}/wrapper_{}.rs", *OUT_DIR, file_name)).exists() {
-            writeln!(
-                f,
-                "{:level$}include!(\"wrapper_{}.rs\");",
-                "",
-                file_name,
-                level = level
-            )
-            .unwrap();
+            writeln!(f, "include!(\"wrapper_{}.rs\");", file_name,).unwrap();
         }
-        for l in (0..level).rev() {
-            writeln!(f, "{:1$}}}", "", l).unwrap();
-        }
+        writeln!(f, "{}", "}\n".repeat(level)).unwrap();
     }
+}
+
+// List all `.rs` files in `OUT_DIR`.
+fn list_rs_files() -> impl Iterator<Item = PathBuf> {
+    fs::read_dir(&*OUT_DIR)
+        .expect("Couldn't read directory")
+        .filter_map(|e| {
+            let path = e.expect("Couldn't list file").path();
+            if path.extension() == Some(std::ffi::OsStr::new("rs")) {
+                Some(path)
+            } else {
+                None
+            }
+        })
 }

--- a/src/prost_impl.rs
+++ b/src/prost_impl.rs
@@ -1,6 +1,5 @@
-use super::wrapper::GenOpt;
-use crate::OUT_DIR;
-use std::fs;
+use crate::wrapper::{GenOpt, WrapperGen};
+use crate::{list_rs_files, OUT_DIR};
 use std::path::Path;
 
 pub fn generate<T: AsRef<Path>>(includes: &[T], files: &[T]) {
@@ -16,44 +15,5 @@ pub fn generate<T: AsRef<Path>>(includes: &[T], files: &[T]) {
             .unwrap();
     }
 
-    let mod_names = module_names_for_dir(&*OUT_DIR);
-    generate_wrappers(
-        &mod_names
-            .iter()
-            .map(|m| format!("{}/{}.rs", *OUT_DIR, m))
-            .collect::<Vec<_>>(),
-        GenOpt::all(),
-    );
-}
-
-fn generate_wrappers<T: AsRef<str>>(file_names: &[T], gen_opt: GenOpt) {
-    for file in file_names {
-        let gen = super::wrapper::WrapperGen::new(file.as_ref(), gen_opt);
-        gen.write();
-    }
-}
-
-/// Returns a list of module names corresponding to the Rust files in a directory.
-///
-/// Note that this does not read the files so will miss inline modules, it only
-/// looks at filenames,
-fn module_names_for_dir(directory_name: &str) -> Vec<String> {
-    let mut mod_names: Vec<_> = fs::read_dir(directory_name)
-        .expect("Couldn't read directory")
-        .filter_map(|e| {
-            let file_name = e.expect("Couldn't list file").file_name();
-            let file_name = file_name.to_string_lossy();
-            if !file_name.ends_with(".rs") {
-                return None;
-            }
-            file_name
-                .split(".rs")
-                .next()
-                .filter(|n| !n.starts_with("wrapper_"))
-                .map(ToOwned::to_owned)
-        })
-        .collect();
-
-    mod_names.sort();
-    mod_names
+    list_rs_files().for_each(|path| WrapperGen::new(path, GenOpt::all()).write());
 }

--- a/src/prost_impl.rs
+++ b/src/prost_impl.rs
@@ -2,17 +2,17 @@ use crate::wrapper::WrapperGen;
 use crate::{list_rs_files, Builder, OUT_DIR};
 
 impl Builder {
-    pub fn generate_files(&self, files: &[String]) {
+    pub fn generate_files(&self) {
         #[cfg(feature = "grpcio-prost-codec")]
         {
-            grpcio_compiler::prost_codegen::compile_protos(files, &self.includes, &*OUT_DIR)
+            grpcio_compiler::prost_codegen::compile_protos(&self.files, &self.includes, &*OUT_DIR)
                 .unwrap();
         }
         #[cfg(not(feature = "grpcio-prost-codec"))]
         {
             prost_build::Config::new()
                 .out_dir(&*OUT_DIR)
-                .compile_protos(files, &self.includes)
+                .compile_protos(&self.files, &self.includes)
                 .unwrap();
         }
 

--- a/src/prost_impl.rs
+++ b/src/prost_impl.rs
@@ -1,0 +1,45 @@
+use super::wrapper::GenOpt;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+pub fn rustfmt(file_path: &Path) {
+    let output = Command::new("rustfmt")
+        .arg(file_path.to_str().unwrap())
+        .output();
+    if !output.map(|o| o.status.success()).unwrap_or(false) {
+        eprintln!("Rustfmt failed");
+    }
+}
+
+pub fn generate_wrappers<T: AsRef<str>>(file_names: &[T], out_dir: &str, gen_opt: GenOpt) {
+    for file in file_names {
+        let gen = super::wrapper::WrapperGen::new(file.as_ref(), gen_opt);
+        gen.write(out_dir);
+    }
+}
+
+/// Returns a list of module names corresponding to the Rust files in a directory.
+///
+/// Note that this does not read the files so will miss inline modules, it only
+/// looks at filenames,
+pub fn module_names_for_dir(directory_name: &str) -> Vec<String> {
+    let mut mod_names: Vec<_> = fs::read_dir(directory_name)
+        .expect("Couldn't read directory")
+        .filter_map(|e| {
+            let file_name = e.expect("Couldn't list file").file_name();
+            let file_name = file_name.to_string_lossy();
+            if !file_name.ends_with(".rs") {
+                return None;
+            }
+            file_name
+                .split(".rs")
+                .next()
+                .filter(|n| !n.starts_with("wrapper_"))
+                .map(ToOwned::to_owned)
+        })
+        .collect();
+
+    mod_names.sort();
+    mod_names
+}

--- a/src/prost_impl.rs
+++ b/src/prost_impl.rs
@@ -1,21 +1,26 @@
 use crate::wrapper::WrapperGen;
-use crate::{list_rs_files, Builder, OUT_DIR};
+use crate::Builder;
 
 impl Builder {
     pub fn generate_files(&self) {
         #[cfg(feature = "grpcio-prost-codec")]
         {
-            grpcio_compiler::prost_codegen::compile_protos(&self.files, &self.includes, &*OUT_DIR)
-                .unwrap();
+            grpcio_compiler::prost_codegen::compile_protos(
+                &self.files,
+                &self.includes,
+                &self.out_dir,
+            )
+            .unwrap();
         }
         #[cfg(not(feature = "grpcio-prost-codec"))]
         {
             prost_build::Config::new()
-                .out_dir(&*OUT_DIR)
+                .out_dir(&self.out_dir)
                 .compile_protos(&self.files, &self.includes)
                 .unwrap();
         }
 
-        list_rs_files().for_each(|path| WrapperGen::new(path, self.wrapper_opts).write());
+        self.list_rs_files()
+            .for_each(|path| WrapperGen::new(path, self.wrapper_opts).write());
     }
 }

--- a/src/protobuf_impl.rs
+++ b/src/protobuf_impl.rs
@@ -58,7 +58,7 @@ impl Builder {
             .arg("-o")
             .arg(&desc_file);
         for f in &self.files {
-            cmd.arg(&format!("{}", f));
+            cmd.arg(f);
         }
         println!("executing {:?}", cmd);
         match cmd.status() {
@@ -101,8 +101,6 @@ fn generate_grpcio(
     desc: &[protobuf::descriptor::FileDescriptorProto],
     files_to_generate: &[String],
 ) {
-    use std::io::Write;
-
     let output_dir = std::path::Path::new(&*OUT_DIR);
     let results = grpcio_compiler::codegen::gen(desc, &files_to_generate);
     for res in results {

--- a/src/protobuf_impl.rs
+++ b/src/protobuf_impl.rs
@@ -46,7 +46,7 @@ fn check_protoc_version(protoc: &str) {
 }
 
 impl Builder {
-    pub fn generate_files(&self, files: &[String]) {
+    pub fn generate_files(&self) {
         check_protoc_version(&get_protoc());
         let mut cmd = Command::new(get_protoc());
         let desc_file = format!("{}/mod.desc", *OUT_DIR);
@@ -57,7 +57,7 @@ impl Builder {
             .arg("--include_source_info")
             .arg("-o")
             .arg(&desc_file);
-        for f in files {
+        for f in &self.files {
             cmd.arg(&format!("{}", f));
         }
         println!("executing {:?}", cmd);
@@ -70,7 +70,7 @@ impl Builder {
         let desc: protobuf::descriptor::FileDescriptorSet =
             protobuf::parse_from_bytes(&desc_bytes).unwrap();
         let mut files_to_generate = Vec::new();
-        'outer: for file in files {
+        'outer: for file in &self.files {
             for include in &self.includes {
                 if let Ok(truncated) = Path::new(file).strip_prefix(include) {
                     files_to_generate.push(format!("{}", truncated.display()));

--- a/src/protobuf_impl.rs
+++ b/src/protobuf_impl.rs
@@ -1,0 +1,146 @@
+// Copyright 2019 PingCAP, Inc.
+
+use regex::Regex;
+use std::env;
+use std::fmt::Debug;
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::Path;
+use std::process::Command;
+use std::str::from_utf8;
+
+pub fn get_protoc() -> String {
+    let protoc_bin_name = match (env::consts::OS, env::consts::ARCH) {
+        ("linux", "x86") => "protoc-linux-x86_32",
+        ("linux", "x86_64") => "protoc-linux-x86_64",
+        ("linux", "aarch64") => "protoc-linux-aarch_64",
+        ("linux", "ppcle64") => "protoc-linux-ppcle_64",
+        ("macos", "x86_64") => "protoc-osx-x86_64",
+        ("windows", _) => "protoc-win32.exe",
+        _ => return "protoc".to_owned(),
+    };
+    let bin_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("bin")
+        .join(protoc_bin_name);
+    format!("{}", bin_path.display())
+}
+
+/// Check that the user's installed version of the protobuf compiler is 3.1.x.
+pub fn check_protoc_version(protoc: &str) {
+    let ver_re = Regex::new(r"([0-9]+)\.([0-9]+)\.[0-9]").unwrap();
+    let ver = Command::new(protoc)
+        .arg("--version")
+        .output()
+        .expect("Program `protoc` not installed (is it in PATH?).");
+    let caps = ver_re.captures(from_utf8(&ver.stdout).unwrap()).unwrap();
+    let major = caps.get(1).unwrap().as_str().parse::<i16>().unwrap();
+    let minor = caps.get(2).unwrap().as_str().parse::<i16>().unwrap();
+    if major == 3 && minor < 1 || major < 3 {
+        panic!(
+            "Invalid version of protoc (required at least 3.1.x, get {}.{}.x).",
+            major, minor,
+        );
+    }
+}
+pub fn generate<T: AsRef<Path> + Debug>(includes: &[T], files: &[T], out_dir: &str) {
+    check_protoc_version(&get_protoc());
+    let mut cmd = Command::new(get_protoc());
+    let desc_file = format!("{}/mod.desc", out_dir);
+    for i in includes {
+        cmd.arg(format!("-I{}", i.as_ref().display()));
+    }
+    cmd.arg("--include_imports")
+        .arg("--include_source_info")
+        .arg("-o")
+        .arg(&desc_file);
+    for f in files {
+        cmd.arg(&format!("{}", f.as_ref().display()));
+    }
+    println!("executing {:?}", cmd);
+    match cmd.status() {
+        Ok(e) if e.success() => {}
+        e => panic!("failed to generate descriptor set files: {:?}", e),
+    }
+
+    let desc_bytes = std::fs::read(&desc_file).unwrap();
+    let desc: protobuf::descriptor::FileDescriptorSet =
+        protobuf::parse_from_bytes(&desc_bytes).unwrap();
+    let mut files_to_generate = Vec::new();
+    'outer: for file in files {
+        for include in includes {
+            if let Ok(truncated) = file.as_ref().strip_prefix(include) {
+                files_to_generate.push(format!("{}", truncated.display()));
+                continue 'outer;
+            }
+        }
+
+        panic!("file {:?} is not found in includes {:?}", file, includes);
+    }
+
+    protobuf_codegen::gen_and_write(
+        desc.get_file(),
+        &files_to_generate,
+        &Path::new(out_dir),
+        &protobuf_codegen::Customize::default(),
+    )
+    .unwrap();
+    generate_grpcio(&desc.get_file(), &files_to_generate, out_dir);
+    replace_read_unknown_fields(out_dir);
+}
+
+#[cfg(feature = "grpcio-protobuf-codec")]
+pub fn generate_grpcio(
+    desc: &[protobuf::descriptor::FileDescriptorProto],
+    files_to_generate: &[String],
+    out_dir: &str,
+) {
+    use std::io::Write;
+
+    let output_dir = std::path::Path::new(out_dir);
+    let results = grpcio_compiler::codegen::gen(desc, &files_to_generate);
+    for res in results {
+        let out_file = output_dir.join(&res.name);
+        let mut f = std::fs::File::create(&out_file).unwrap();
+        f.write_all(&res.content).unwrap();
+    }
+}
+
+#[cfg(all(feature = "protobuf-codec", not(feature = "grpcio-protobuf-codec")))]
+pub fn generate_grpcio(_: &[protobuf::descriptor::FileDescriptorProto], _: &[String], _: &str) {}
+
+/// Convert protobuf files to use the old way of reading protobuf enums.
+// FIXME: Remove this once stepancheg/rust-protobuf#233 is resolved.
+pub fn replace_read_unknown_fields(out_dir: &str) {
+    let regex =
+        Regex::new(r"::protobuf::rt::read_proto3_enum_with_unknown_fields_into\(([^,]+), ([^,]+), &mut ([^,]+), [^\)]+\)\?").unwrap();
+    for f in fs::read_dir(out_dir).unwrap() {
+        let path = match f {
+            Ok(p) => p.path(),
+            Err(e) => panic!("failed to list {}: {:?}", out_dir, e),
+        };
+        if path.extension() != Some(std::ffi::OsStr::new("rs")) {
+            continue;
+        }
+
+        let mut text = String::new();
+        let mut f = File::open(&path).unwrap();
+        f.read_to_string(&mut text)
+            .expect("Couldn't read source file");
+
+        // FIXME Rustfmt bug in string literals
+        #[rustfmt::skip]
+        let text = {
+            regex.replace_all(
+                &text,
+                "if $1 == ::protobuf::wire_format::WireTypeVarint {\
+                    $3 = $2.read_enum()?;\
+                } else {\
+                    return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));\
+                }",
+            )
+        };
+        let mut out = File::create(&path).unwrap();
+        out.write_all(text.as_bytes())
+            .expect("Could not write source file");
+    }
+}

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,4 +1,3 @@
-use crate::rustfmt;
 use bitflags::bitflags;
 use quote::ToTokens;
 use std::fs::{self, File};
@@ -64,15 +63,14 @@ impl WrapperGen {
         }
     }
 
-    pub fn write(&self, out_dir: &str) {
+    pub fn write(&self) {
         let mut path = PathBuf::new();
-        path.push(out_dir);
+        path.push(&*crate::OUT_DIR);
         path.push(&self.name);
         {
             let mut out = BufWriter::new(File::create(&path).expect("Could not create file"));
             self.generate(&mut out).expect("Error generating code");
         }
-        rustfmt(&path);
     }
 
     fn generate<W>(&self, buf: &mut W) -> Result<(), io::Error>

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 PingCAP, Inc.
 
-use bitflags::bitflags;
+use crate::GenOpt;
 use quote::ToTokens;
 use std::fs::{self, File};
 use std::io::{self, BufWriter, Write};
@@ -9,39 +9,6 @@ use syn::{
     Attribute, GenericArgument, Ident, Item, ItemEnum, ItemStruct, Meta, NestedMeta, PathArguments,
     Type,
 };
-
-bitflags! {
-    pub struct GenOpt: u32 {
-        /// Generate implementation for trait `::protobuf::Message`.
-        const MESSAGE = 0b0000_0001;
-        /// Generate getters.
-        const TRIVIAL_GET = 0b0000_0010;
-        /// Generate setters.
-        const TRIVIAL_SET = 0b0000_0100;
-        /// Generate the `new_` constructors.
-        const NEW = 0b0000_1000;
-        /// Generate `clear_*` functions.
-        const CLEAR = 0b0001_0000;
-        /// Generate `has_*` functions.
-        const HAS = 0b0010_0000;
-        /// Generate mutable getters.
-        const MUT = 0b0100_0000;
-        /// Generate `take_*` functions.
-        const TAKE = 0b1000_0000;
-        /// Except `impl protobuf::Message`.
-        const NO_MSG = Self::TRIVIAL_GET.bits
-         | Self::TRIVIAL_SET.bits
-         | Self::CLEAR.bits
-         | Self::HAS.bits
-         | Self::MUT.bits
-         | Self::TAKE.bits;
-        /// Except `new_` and `impl protobuf::Message`.
-        const ACCESSOR = Self::TRIVIAL_GET.bits
-         | Self::TRIVIAL_SET.bits
-         | Self::MUT.bits
-         | Self::TAKE.bits;
-    }
-}
 
 pub struct WrapperGen {
     input: String,


### PR DESCRIPTION
This PR restores some flexibility in generating the wrappers for Prost and makes the builder easier to use.

PTAL @ice1000 @BusyJay The PR is probably easier to review one commit at a time.

To see how the API is improved, here is the KvProto diff to build.rs as an example:

<details>

```diff
diff --git a/build.rs b/build.rs
index 26cabaa..1b3acbf 100644
--- a/build.rs
+++ b/build.rs
@@ -11,56 +11,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use protobuf_build::*;
-use std::fs::read_dir;
-use std::fs::File;
-use std::io::prelude::*;
-use std::io::BufReader;
-use std::path::Path;
-
-const BLACK_LIST: &[&str] = &["protobuf", "google", "gogoproto", "eraftpb"];
+use protobuf_build::{Builder, GenOpt};
 
 fn main() {
-    let out_dir = format!("{}/protos", std::env::var("OUT_DIR").unwrap());
-    let file_names: Vec<_> = read_dir("proto")
-        .expect("Couldn't read proto directory")
-        .map(|e| {
-            format!(
-                "proto/{}",
-                e.expect("Couldn't list file").file_name().to_string_lossy()
-            )
-        })
-        .collect();
-
-    generate_files(
-        &["include".to_owned(), "proto".to_owned()],
-        &file_names,
-        &out_dir,
-    );
-    let mod_file_path = Path::new(&out_dir).join("mod.rs");
-    let mod_file = File::open(&mod_file_path).unwrap();
-    let reader = BufReader::new(mod_file);
-    let mut content = Vec::new();
-    let mut lines = reader.lines();
-    while let Some(l) = lines.next() {
-        let l = l.unwrap();
-        if BLACK_LIST.iter().any(|i| l.contains(i)) {
-            let mut level = 1;
-            while level > 0 {
-                let l = lines.next().unwrap().unwrap();
-                if l.contains('{') {
-                    level += 1;
-                }
-                if l.contains('}') {
-                    level -= 1;
-                }
-            }
-        } else {
-            content.push(l);
-        }
-    }
-    let mut mod_file = File::create(&mod_file_path).unwrap();
-    for l in content {
-        writeln!(mod_file, "{}", l).unwrap();
-    }
+    Builder::new()
+        .search_dir_for_protos("proto")
+        .append_black_listed_include("eraftpb".to_owned())
+        .wrapper_options(
+            GenOpt::MUT
+                | GenOpt::TRIVIAL_GET
+                | GenOpt::TRIVIAL_SET
+                | GenOpt::HAS
+                | GenOpt::TAKE
+                | GenOpt::CLEAR,
+        )
+        .generate();
 }
```
</details>