### PR TITLE
Changes to make rust-proto and Prost code more similar.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub struct Builder {
     out_dir: String,
     wrapper_opts: GenOpt,
     package_name: Option<String>,
+    re_export_services: bool,
 }
 
 impl Builder {
@@ -45,6 +46,7 @@ impl Builder {
             ),
             wrapper_opts: GenOpt::all(),
             package_name: None,
+            re_export_services: true,
         }
     }
 
@@ -119,6 +121,13 @@ impl Builder {
     /// in any case.
     pub fn package_name(&mut self, package_name: impl Into<String>) -> &mut Self {
         self.package_name = Some(package_name.into());
+        self
+    }
+
+    /// Whether services defined in separate modules should be re-exported from
+    /// their corresponding module. Default is `true`.
+    pub fn re_export_services(&mut self, re_export_services: bool) -> &mut Self {
+        self.re_export_services = re_export_services;
         self
     }
 


### PR DESCRIPTION
The first commit is for rust-protobuf and re-exports service code in the protobuf modules. That means that the Prost and rust-protobuf module layouts are more similar, making integration easier. See https://github.com/tikv/tikv/pull/5275/files for the impact on TiKV.

The second commit does a better job with the wrapper functions we generate for Prost where the field is called `type`, in this case we generate `get_type` instead of `get_field_type`, this matches our fork of rust-proto, rather than rust-proto 2.x branches.

PTAL @ice1000 @BusyJay 