### PR TITLE
wrapper: Vec fields have &[] return types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "protobuf-build"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio-compiler 0.5.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protobuf-build"
-version = "0.9.2"
+version = "0.10.0"
 authors = ["Nick Cameron <nrc@ncameron.org>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
e.g., a field `bar` with type `Vec<Foo>` would generate a getter: `get_bar() -> &[Foo]`.

This makes our Prost and rust-protobuf versions closer.

PTAL @brson @sticnarf 