### PR TITLE
Extend PR #30 - use system protoc

### DIFF
--- a/src/protobuf_impl.rs
+++ b/src/protobuf_impl.rs
@@ -12,20 +12,10 @@ use std::str::from_utf8;
 // We use system protoc when its version matches,
 // otherwise use the protoc from bin which we bundle with the crate.
 fn get_protoc() -> String {
-    let ver_re = Regex::new(r"([0-9]+)\.([0-9]+)\.[0-9]").unwrap();
-    let output = Command::new("protoc").arg("--version").output();
-    match output {
-        Ok(o) => {
-            let caps = ver_re.captures(from_utf8(&o.stdout).unwrap()).unwrap();
-            let major = caps.get(1).unwrap().as_str().parse::<i16>().unwrap();
-            let minor = caps.get(2).unwrap().as_str().parse::<i16>().unwrap();
-            if major == 3 && minor >= 1 {
-                return "protoc".to_owned();
-            }
-            println!("The system `protoc` version mismatch, require >= 3.1.0, got {}.{}.x, fallback to the bundled `protoc`", major, minor);
-        }
-        Err(_) => println!("`protoc` not in PATH, try using the bundled protoc"),
-    };
+    if let Ok(s) = check_system_version() {
+        return s;
+    }
+
     // The bundled protoc should always match the version
     let protoc_bin_name = match (env::consts::OS, env::consts::ARCH) {
         ("linux", "x86") => "protoc-linux-x86_32",
@@ -40,6 +30,25 @@ fn get_protoc() -> String {
         .join("bin")
         .join(protoc_bin_name);
     bin_path.display().to_string()
+}
+
+fn check_system_version() -> Result<String, ()> {
+    let ver_re = Regex::new(r"([0-9]+)\.([0-9]+)\.[0-9]").unwrap();
+    let output = Command::new("protoc").arg("--version").output();
+    match output {
+        Ok(o) => {
+            let caps = ver_re.captures(from_utf8(&o.stdout).unwrap()).unwrap();
+            let major = caps.get(1).unwrap().as_str().parse::<i16>().unwrap();
+            let minor = caps.get(2).unwrap().as_str().parse::<i16>().unwrap();
+            if major == 3 && minor >= 1 {
+                return Ok("protoc".to_owned());
+            }
+            println!("The system `protoc` version mismatch, require >= 3.1.0, got {}.{}.x, fallback to the bundled `protoc`", major, minor);
+        }
+        Err(_) => println!("`protoc` not in PATH, try using the bundled protoc"),
+    };
+
+    Err(())
 }
 
 impl Builder {


### PR DESCRIPTION
This PR takes #30 and factors out `check_system_version` as requested in https://github.com/tikv/protobuf-build/pull/30#discussion_r351085152

PTAL @tennix @Hoverbear @BusyJay 