### PR TITLE
Allow PROTOC env var to dictate protoc path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protobuf-build"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Nick Cameron <nrc@ncameron.org>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/protobuf_impl.rs
+++ b/src/protobuf_impl.rs
@@ -14,7 +14,12 @@ use crate::Builder;
 // We use system protoc when its version matches,
 // otherwise use the protoc from bin which we bundle with the crate.
 fn get_protoc() -> String {
-    if let Ok(s) = check_system_version() {
+    // $PROTOC overrides everything; if it isn't a useful version then fail.
+    if let Ok(s) = env::var("PROTOC") {
+        check_protoc_version(&s).expect("PROTOC version not usable");
+        return s;
+    }
+    if let Ok(s) = check_protoc_version("protoc") {
         return s;
     }
 
@@ -34,16 +39,16 @@ fn get_protoc() -> String {
     bin_path.display().to_string()
 }
 
-fn check_system_version() -> Result<String, ()> {
+fn check_protoc_version(protoc: &str) -> Result<String, ()> {
     let ver_re = Regex::new(r"([0-9]+)\.([0-9]+)\.[0-9]").unwrap();
-    let output = Command::new("protoc").arg("--version").output();
+    let output = Command::new(protoc).arg("--version").output();
     match output {
         Ok(o) => {
             let caps = ver_re.captures(from_utf8(&o.stdout).unwrap()).unwrap();
             let major = caps.get(1).unwrap().as_str().parse::<i16>().unwrap();
             let minor = caps.get(2).unwrap().as_str().parse::<i16>().unwrap();
             if major == 3 && minor >= 1 {
-                return Ok("protoc".to_owned());
+                return Ok(protoc.to_owned());
             }
             println!("The system `protoc` version mismatch, require >= 3.1.0, got {}.{}.x, fallback to the bundled `protoc`", major, minor);
         }


### PR DESCRIPTION
If `PROTOC` is set, then use that as the path for `protoc`, overriding the path search and the vendored binaries.

No-op if `PROTOC` is not set.