### PR TITLE
Handle recursive types, which Prost wraps in a Box

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protobuf-build"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Nick Cameron <nrc@ncameron.org>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -12,10 +12,11 @@ description = "Utility functions for generating Rust code from protobufs (using 
 default = ["protobuf-codec"]
 protobuf-codec = ["protobuf-codegen", "protobuf", "regex"]
 grpcio-protobuf-codec = ["grpcio-compiler/protobuf-codec", "protobuf-codec"]
-prost-codec = ["syn", "quote", "prost-build"]
+prost-codec = ["syn", "quote", "prost-build", "proc-macro2"]
 grpcio-prost-codec = ["grpcio-compiler/prost-codec", "prost-codec"]
 
 [dependencies]
+proc-macro2 = { version = "1", optional = true }
 protobuf = { version = "2", optional = true }
 protobuf-codegen = { version = "2", optional = true }
 grpcio-compiler = { version = "0.5.0", default-features = false, optional = true }


### PR DESCRIPTION
Fixes https://github.com/pingcap/tipb/issues/184

When a message is recursive, Prost uses `Box<Foo>` instead of just `Foo` for the recursive fields. Previously we were not handling these. This PR fixes that issue in two parts: first, when a type with parameters appears in expression context then it must use the turbofish style of angle brackets, e.g., `Box::<Foo>::default()`. Second, the type returned from `get_*` must be adjusted from, e.g., `&Box<Foo>` to the more idiomatic `&Foo`. This is not just a matter of style, because we have a reference to a static as our default reference type (which has type `&'static Foo`) without this change there is a type mismatch.

PTAL @BusyJay 