### PR TITLE
Handle repeated built-in types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protobuf-build"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["Nick Cameron <nrc@ncameron.org>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -463,7 +463,14 @@ impl FieldKind {
                 // that unwrapped_type may start with `super` so if we just smoosh the two together we
                 // get an invalid type. So the following small nightmare of code pops a suffix of
                 // prefix for every `super`, while there are both `super`s and segments of the prefix.
-                let mut segments: Vec<_> = prefix.split("::").collect();
+                let mut segments: Vec<_> = if ["bool", "u32", "i32", "u64", "i32", "f32", "f64"]
+                    .contains(&unwrapped_type)
+                {
+                    // A built-in type should never be prefixed.
+                    Vec::new()
+                } else {
+                    prefix.split("::").collect()
+                };
                 while let Some(s) = segments.pop() {
                     if s.is_empty() {
                         continue;


### PR DESCRIPTION
This commit was missing from my previous PR. It adds some special casing for built-in types. (Needed to fix https://github.com/pingcap/kvproto/pull/622).

PTAL @BusyJay 