### PR TITLE
allow to use latest grpcio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ grpcio-prost-codec = ["grpcio-compiler/prost-codec", "prost-codec"]
 proc-macro2 = { version = "1", optional = true }
 protobuf = { version = "2", optional = true }
 protobuf-codegen = { version = "2", optional = true }
-grpcio-compiler = { version = "0.5.0", default-features = false, optional = true }
+grpcio-compiler = { version = ">=0.5.0", default-features = false, optional = true }
 prost-build = { version = "0.6", optional = true }
 regex = { version = "1.3", optional = true }
 syn = { version = "1.0", features = ["full"], optional = true }


### PR DESCRIPTION
grpcio 0.6.0 introduces std futures, which changes the syntax of
generated services. Use ">=0.5.0" instead of "0.6.0" to allow updating
grpcio without touching protobuf-build in the future.

Currently there is cycle dependencies between grpcio and protobuf-build.
To update grpcio-proto, protobuf-build has to be updated first to use
latest grpcio-compiler so that grpcio-proto can utilize latest syntax.
But grpcio-compiler is not released yet due to CI failure, which is
caused by outdated sources generated in grpcio-proto by protobuf-build.