### PR TITLE
Fix links in generated files so it can be properly used in rust docs.

### DIFF
--- a/src/protobuf_impl.rs
+++ b/src/protobuf_impl.rs
@@ -80,7 +80,7 @@ impl Builder {
 
         let desc_bytes = std::fs::read(&desc_file).unwrap();
         let desc: protobuf::descriptor::FileDescriptorSet =
-            protobuf::parse_from_bytes(&desc_bytes).unwrap();
+            protobuf::Message::parse_from_bytes(&desc_bytes).unwrap();
         let mut files_to_generate = Vec::new();
         'outer: for file in &self.files {
             for include in &self.includes {


### PR DESCRIPTION
It replaces ` https://www.example.com ` with `` `<https://www.example.com>` ``
so that generated rust doc contains propper links.

To see what is wrong see e.g.
https://www.tikv.dev/doc/rust-client/tikv_client_proto/kvrpcpb/struct.ScanDetailV2.html#structfield.rocksdb_key_skipped_count
The link is treated as a text here.