### PR TITLE
allow grpcio >= 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ grpcio-prost-codec = ["grpcio-compiler/prost-codec", "prost-codec"]
 proc-macro2 = { version = "1", optional = true }
 protobuf = { version = "2", optional = true }
 protobuf-codegen = { version = "2", optional = true }
-grpcio-compiler = { version = "0.8", default-features = false, optional = true }
+grpcio-compiler = { version = ">=0.8", default-features = false, optional = true }
 prost-build = { version = "0.7", optional = true }
 regex = { version = "1.3", optional = true }
 syn = { version = "1.0", features = ["full"], optional = true }


### PR DESCRIPTION
Refer to: https://github.com/tikv/protobuf-build/pull/46/files#r579994268

It would be easier when upgrading grpcio version to higher if we allow `grpcio >= 0.8`.