### PR TITLE
bump protobuf for RUSTSEC-2019-0003

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ grpcio-prost-codec = ["grpcio-compiler/prost-codec", "prost-codec"]
 
 [dependencies]
 proc-macro2 = { version = "1", optional = true }
-protobuf = { version = "2", optional = true }
+protobuf = { version = "2.8", optional = true }
 protobuf-codegen = { version = "2", optional = true }
 grpcio-compiler = { version = ">=0.8", default-features = false, optional = true }
 prost-build = { version = "0.7", optional = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,7 +11,7 @@ protobuf-codec = ["protobuf-build/grpcio-protobuf-codec"]
 prost-codec = ["protobuf-build/grpcio-prost-codec"]
 
 [dependencies]
-protobuf = "2"
+protobuf = "2.8"
 prost = "0.7"
 prost-derive = "0.7"
 lazy_static = "1.4"


### PR DESCRIPTION
Just bump protobuf to 2.8, consistent with tikv, avoid RUSTSEC-2019-0003 

Signed-off-by: Chojan Shang <psiace@outlook.com>