### PR TITLE
support protobuf serialize

### DIFF
--- a/src/protobuf_impl.rs
+++ b/src/protobuf_impl.rs
@@ -103,7 +103,10 @@ impl Builder {
             desc.get_file(),
             &files_to_generate,
             Path::new(&self.out_dir),
-            &protobuf_codegen::Customize::default(),
+            &protobuf_codegen::Customize {
+                serde_derive: Some(true),
+                ..Default::default()
+            },
         )
         .unwrap();
         self.generate_grpcio(desc.get_file(), &files_to_generate);


### PR DESCRIPTION
Signed-off-by: husharp <jinhao.hu@pingcap.com>

rely on https://docs.rs/protobuf-codegen/2.8.0/protobuf_codegen/struct.Customize.html#structfield.serde_derive, 
For support Serialize we can Just turn on the serde_derive option.