### PR TITLE
fix: exclude the whole protobuf-src on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protobuf-build"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Nick Cameron <nrc@ncameron.org>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -19,13 +19,15 @@ grpcio-prost-codec = ["grpcio-compiler/prost-codec", "prost-codec"]
 proc-macro2 = { version = "1", optional = true }
 protobuf = { version = "2", optional = true }
 protobuf-codegen = { version = "2", optional = true }
-protobuf-src = "1.1.0"
 grpcio-compiler = { version = ">=0.8", default-features = false, optional = true }
 prost-build = { version = "0.11", optional = true }
 regex = { version = "1.3" }
 syn = { version = "1.0", features = ["full"], optional = true }
 quote = { version = "1.0", optional = true }
 bitflags = "1.2"
+
+[target.'cfg(not(windows))'.dependencies]
+protobuf-src = "1.1.0"
 
 [workspace]
 members = ["tests"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,16 +39,15 @@ fn get_protoc() -> String {
     }
 
     // The bundled protoc should always match the version
-    if let Some(protoc_bin_name) = match (env::consts::OS, env::consts::ARCH) {
-        ("windows", _) => Some("protoc-win32.exe"),
-        _ => None,
-    } {
+    #[cfg(windows)]
+    {
         let bin_path = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("bin")
-            .join(protoc_bin_name);
-        return bin_path.display().to_string();
+            .join("protoc-win32.exe");
+        bin_path.display().to_string()
     }
 
+    #[cfg(not(windows))]
     protobuf_src::protoc().display().to_string()
 }
 


### PR DESCRIPTION
protobuf-src itself has a build.rs that will fail on windows.

I'll try raft-rs with this branch to verify that we don't miss anything else.