### PR TITLE
Bump prost to v0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ proc-macro2 = { version = "1", optional = true }
 protobuf = { version = "2", optional = true }
 protobuf-codegen = { version = "2", optional = true }
 grpcio-compiler = { version = ">=0.8", default-features = false, optional = true }
-prost-build = { version = "0.11", optional = true }
+prost-build = { version = "0.12", optional = true }
 regex = { version = "1.3" }
 syn = { version = "1.0", features = ["full"], optional = true }
 quote = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ protobuf-codegen = { version = "2", optional = true }
 grpcio-compiler = { version = ">=0.8", default-features = false, optional = true }
 prost-build = { version = "0.12", optional = true }
 regex = { version = "1.3" }
-syn = { version = "1.0", features = ["full"], optional = true }
+syn = { version = "2.0", features = ["full"], optional = true }
 quote = { version = "1.0", optional = true }
 bitflags = "1.2"
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -7,8 +7,8 @@ use std::path::PathBuf;
 use proc_macro2::Span;
 use quote::ToTokens;
 use syn::{
-    Attribute, GenericArgument, Ident, Item, ItemEnum, ItemStruct, Meta, NestedMeta, PathArguments,
-    Token, Type, TypePath,
+    Attribute, GenericArgument, Ident, Item, ItemEnum, ItemStruct, Meta, PathArguments, Token,
+    Type, TypePath,
 };
 
 use crate::GenOpt;
@@ -276,8 +276,8 @@ impl FieldKind {
 
         for a in attrs {
             // condition: in prost generated code, `[deprecated]` appears before `[prost(..)]`
-            deprecated = deprecated || a.path.is_ident("deprecated");
-            if a.path.is_ident("prost") {
+            deprecated = deprecated || a.path().is_ident("deprecated");
+            if a.path().is_ident("prost") {
                 if let Ok(Meta::List(list)) = a.parse_meta() {
                     let mut kinds = list
                         .nested
@@ -310,7 +310,7 @@ impl FieldKind {
                                     None
                                 }
                             } else if let NestedMeta::Meta(Meta::NameValue(mnv)) = item {
-                                let value = mnv.lit.clone().into_token_stream().to_string();
+                                let value = mnv.clone().into_token_stream().to_string();
                                 // Trim leading and trailing `"` and add prefix.
                                 let value = format!("{}{}", prefix, &value[1..value.len() - 1]);
                                 if mnv.path.is_ident("bytes") {
@@ -728,8 +728,8 @@ enum MethodKind {
 
 fn is_message(attrs: &[Attribute]) -> bool {
     for a in attrs {
-        if a.path.is_ident("derive") {
-            let tts = a.tokens.to_string();
+        if a.path().is_ident("derive") {
+            let tts = a.to_token_stream().to_string();
             if tts.contains(":: Message") {
                 return true;
             }
@@ -740,8 +740,8 @@ fn is_message(attrs: &[Attribute]) -> bool {
 
 fn is_enum(attrs: &[Attribute]) -> bool {
     for a in attrs {
-        if a.path.is_ident("derive") {
-            let tts = a.tokens.to_string();
+        if a.path().is_ident("derive") {
+            let tts = a.to_token_stream().to_string();
             if tts.contains("Enumeration") {
                 return true;
             }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -757,7 +757,7 @@ fn type_in_expr_context(s: &str) -> String {
     let last_segment = parsed.path.segments.last_mut().unwrap();
     if !last_segment.arguments.is_empty() {
         if let PathArguments::AngleBracketed(ref mut a) = last_segment.arguments {
-            if a.colon2_token == None {
+            if a.colon2_token.is_none() {
                 a.colon2_token = Some(Token![::](Span::call_site()));
             }
         }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,8 +12,8 @@ prost-codec = ["protobuf-build/grpcio-prost-codec"]
 
 [dependencies]
 protobuf = "2"
-prost = "0.11"
-prost-derive = "0.11"
+prost = "0.12"
+prost-derive = "0.12"
 lazy_static = "1.4"
 
 [build-dependencies]


### PR DESCRIPTION
This updates `prost` and related dependencies to v0.12.

We'd like to see this bump because this is blocking other dependency updates for us in [Qdrant](https://github.com/qdrant/qdrant).

Similar to <https://github.com/tikv/protobuf-build/pull/63> but for a newer version.