### PR TITLE
Sort `fs::read_dir` results in Builder for reproducible output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,12 @@ impl Builder {
                 }
             })
             .collect();
+        // `read_dir` yields entries in filesystem-inode order, which makes
+        // the proto file list non-deterministic across hosts and even
+        // across runs on the same host. Sort so the order protoc /
+        // prost_build sees is stable; this is required for reproducible
+        // builds of the resulting `FileDescriptorProto` layout.
+        self.files.sort();
         self
     }
 
@@ -246,9 +252,16 @@ impl Builder {
         fs::create_dir_all(&self.out_dir).unwrap();
     }
 
-    // List all `.rs` files in `self.out_dir`.
+    // List all `.rs` files in `self.out_dir`, sorted by path.
+    //
+    // Sorting matters because `generate_mod_file` consumes this iterator
+    // to write `pub mod foo; include!("foo.rs");` statements into
+    // `mod.rs`. `read_dir` returns entries in filesystem-inode order, so
+    // without sorting the mod declarations — and therefore the rustc
+    // compile/link order and the offsets of per-module statics in
+    // `.rodata` — would vary across builds.
     fn list_rs_files(&self) -> impl Iterator<Item = PathBuf> {
-        fs::read_dir(&self.out_dir)
+        let mut files: Vec<PathBuf> = fs::read_dir(&self.out_dir)
             .expect("Couldn't read directory")
             .filter_map(|e| {
                 let path = e.expect("Couldn't list file").path();
@@ -258,6 +271,9 @@ impl Builder {
                     None
                 }
             })
+            .collect();
+        files.sort();
+        files.into_iter()
     }
 }
 


### PR DESCRIPTION
`Builder::search_dir_for_protos` and `Builder::list_rs_files` both relied on `fs::read_dir`, which returns entries in filesystem-inode order. That inode order is unstable across filesystems, hosts, and even consecutive runs on the same host, and it propagates through the codegen pipeline into the resulting binary:

* The proto file list returned by `search_dir_for_protos` is handed to `protoc` / `prost_build`, so its order determines the entry order of the generated `FileDescriptorSet`.
* The `.rs` files returned by `list_rs_files` are consumed by `generate_mod_file`, which emits `pub mod foo;` / `include!("foo.rs");` statements into `mod.rs` in iteration order. Rust mod-declaration order then drives rustc's compile / link order, which determines where each module's static descriptor data lands in the final `.rodata`.

Without sorting, two successive builds of crates like `tipb` produce binaries that differ by a handful of bytes near
`com.pingcap.tidb.tipb` — small but enough to break byte-for-byte reproducible builds of `tikv-server`. Sorting both lists makes the order stable across builds without altering any public API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-deterministic ordering of generated outputs to ensure consistent and reproducible build results across different runs and environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/protobuf-build/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->